### PR TITLE
Fix numberFormat when showing large negative numbers

### DIFF
--- a/jquery.simplyCountable.js
+++ b/jquery.simplyCountable.js
@@ -49,13 +49,19 @@
       }
       
       var numberFormat = function(ct){
+        var prefix = '';
         if (options.thousandSeparator){
-          ct = ct.toString();
+          ct = ct.toString();          
+          // Handle large negative numbers
+          if (ct.match(/^-/)) { 
+            ct = ct.substr(1);
+            prefix = '-';
+          }
           for (var i = ct.length-3; i > 0; i -= 3){
             ct = ct.substr(0,i) + options.thousandSeparator + ct.substr(i);
           }
         }
-        return ct;
+        return prefix + ct;
       }
       
       /* Calculates count for either words or characters */


### PR DESCRIPTION
Hey Aaron,

When the following options are used:

strictMax:          false
countDirection:     'down'
thousandSeparator:  ','

and the user enters over 100 characters too many (making the counter go into the negative), the interface shows:

"You have -,150 characters remaining."

This fixes the comma being added on negative numbers. Thanks for the plugin!

Cheers!

-Ryan
