### PR TITLE
Fixed issue on blur event when strictMax is true

### DIFF
--- a/jquery.simplyCountable.js
+++ b/jquery.simplyCountable.js
@@ -105,6 +105,7 @@
     
     countCheck();
     countable.keyup(countCheck);
+    countable.blur(countCheck);
     countable.bind('paste', function(){
       // Wait a few miliseconds for the pasting
       setTimeout(countCheck, 5);


### PR DESCRIPTION
Hello @aaronrussell,

I've realized that when strictMax is true, there is an issue on blur event. If you keep a key pressed until the maximum characters be exceeded and press the tab key, then the exceeded text won't be dropped.

I don't know if that is really a problem, but I would like to let you know about it. BTW, great job! :)

Regards,
Jivago
