### PR TITLE
Containers allowing multiple selector matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Advanced usage:
 
     $('#my_textarea').simplyCountable({
         counter:            '#counter',
+        container:          document,
         countType:          'characters',
         wordSeparator:      ' ',
         maxCount:           140,
@@ -32,6 +33,7 @@ Advanced usage:
 ## Options
 
 * `counter` - A jQuery selector to match the 'counter' element. Defaults to `#counter`.
+* `container` - A jQuery selector that contains the form element and the 'counter' element in. Defaults to `document`.
 * `countType` - Select whether to count `characters` or `words`. Defaults to `characters`.
 * `wordSeparator` - The word separator when counting `words`. Defaults to _white-space_.
 * `maxCount` - The maximum character (or word) count of the text input or textarea. Defaults to `140`.

--- a/jquery.simplyCountable.js
+++ b/jquery.simplyCountable.js
@@ -17,6 +17,7 @@
     
     options = $.extend({
       counter:            '#counter',
+      container:          document,
       countType:          'characters',
       wordSeparator:      ' ',
       maxCount:           140,
@@ -30,84 +31,88 @@
       onMaxCount:         function(){}
     }, options);
     
-    var countable = this;
-    var counter = $(options.counter);
-    if (!counter.length) { return false; }
-    regex = new RegExp('['+options.wordSeparator+']+');
-    
-    var countCheck = function(){
-           
-      var count;
-      var revCount;
+    $(this).each(function(){
+
+      var countable = $(this);
+      var counter = $(countable).parents(options.container).find(options.counter);
+      if (!counter.length) { return false; }
+      regex = new RegExp('['+options.wordSeparator+']+');
       
-      var reverseCount = function(ct){
-        return ct - (ct*2) + options.maxCount;
-      }
-      
-      var countInt = function(){
-        return (options.countDirection === 'up') ? revCount : count;
-      }
-      
-      var numberFormat = function(ct){
-        var prefix = '';
-        if (options.thousandSeparator){
-          ct = ct.toString();          
-          // Handle large negative numbers
-          if (ct.match(/^-/)) { 
-            ct = ct.substr(1);
-            prefix = '-';
-          }
-          for (var i = ct.length-3; i > 0; i -= 3){
-            ct = ct.substr(0,i) + options.thousandSeparator + ct.substr(i);
-          }
+      var countCheck = function(){
+             
+        var count;
+        var revCount;
+        
+        var reverseCount = function(ct){
+          return ct - (ct*2) + options.maxCount;
         }
-        return prefix + ct;
-      }
-      
-      /* Calculates count for either words or characters */
-      if (options.countType === 'words'){
-        count = options.maxCount - $.trim(countable.val()).split(regex).length;
-        if (countable.val() === ''){ count += 1; }
-      }
-      else { count = options.maxCount - countable.val().length; }
-      revCount = reverseCount(count);
-      
-      /* If strictMax set restrict further characters */
-      if (options.strictMax && count <= 0){
-        var content = countable.val();
-        if (count < 0 || content.match(new RegExp('['+options.wordSeparator+']$'))) {
-          options.onMaxCount(countInt(), countable, counter);
+        
+        var countInt = function(){
+          return (options.countDirection === 'up') ? revCount : count;
         }
+        
+        var numberFormat = function(ct){
+          var prefix = '';
+          if (options.thousandSeparator){
+            ct = ct.toString();          
+            // Handle large negative numbers
+            if (ct.match(/^-/)) { 
+              ct = ct.substr(1);
+              prefix = '-';
+            }
+            for (var i = ct.length-3; i > 0; i -= 3){
+              ct = ct.substr(0,i) + options.thousandSeparator + ct.substr(i);
+            }
+          }
+          return prefix + ct;
+        }
+        
+        /* Calculates count for either words or characters */
         if (options.countType === 'words'){
-          countable.val(content.split(regex).slice(0, options.maxCount).join(options.wordSeparator));
+          count = options.maxCount - $.trim(countable.val()).split(regex).length;
+          if (countable.val() === ''){ count += 1; }
         }
-        else { countable.val(content.substring(0, options.maxCount)); }
-        count = 0, revCount = options.maxCount;
-      }
+        else { count = options.maxCount - countable.val().length; }
+        revCount = reverseCount(count);
+        
+        /* If strictMax set restrict further characters */
+        if (options.strictMax && count <= 0){
+          var content = countable.val();
+          if (count < 0 || content.match(new RegExp('['+options.wordSeparator+']$'))) {
+            options.onMaxCount(countInt(), countable, counter);
+          }
+          if (options.countType === 'words'){
+            countable.val(content.split(regex).slice(0, options.maxCount).join(options.wordSeparator));
+          }
+          else { countable.val(content.substring(0, options.maxCount)); }
+          count = 0, revCount = options.maxCount;
+        }
+        
+        counter.text(numberFormat(countInt()));
+        
+        /* Set CSS class rules and API callbacks */
+        if (!counter.hasClass(options.safeClass) && !counter.hasClass(options.overClass)){
+          if (count < 0){ counter.addClass(options.overClass); }
+          else { counter.addClass(options.safeClass); }
+        }
+        else if (count < 0 && counter.hasClass(options.safeClass)){
+          counter.removeClass(options.safeClass).addClass(options.overClass);
+          options.onOverCount(countInt(), countable, counter);
+        }
+        else if (count >= 0 && counter.hasClass(options.overClass)){
+          counter.removeClass(options.overClass).addClass(options.safeClass);
+          options.onSafeCount(countInt(), countable, counter);
+        }
+        
+      };
       
-      counter.text(numberFormat(countInt()));
-      
-      /* Set CSS class rules and API callbacks */
-      if (!counter.hasClass(options.safeClass) && !counter.hasClass(options.overClass)){
-        if (count < 0){ counter.addClass(options.overClass); }
-        else { counter.addClass(options.safeClass); }
-      }
-      else if (count < 0 && counter.hasClass(options.safeClass)){
-        counter.removeClass(options.safeClass).addClass(options.overClass);
-        options.onOverCount(countInt(), countable, counter);
-      }
-      else if (count >= 0 && counter.hasClass(options.overClass)){
-        counter.removeClass(options.overClass).addClass(options.safeClass);
-        options.onSafeCount(countInt(), countable, counter);
-      }
-      
-    };
-    
-    countCheck();
-    countable.keyup(countCheck);
-    countable.bind('paste', function(){
-      // Wait a few miliseconds for the pasting
-      setTimeout(countCheck, 5);
+      countCheck();
+      countable.keyup(countCheck);
+      countable.bind('paste', function(){
+        // Wait a few miliseconds for the pasting
+        setTimeout(countCheck, 5);
+      });
+
     });
     
   };


### PR DESCRIPTION
This change allows the form field selector to match multiple elements with a common parent selector that contains the target counter element.

For example this Javascript:

```
$('.my-field').simplyCountable(
    counter: '.my-counter',
    container: '.my-container',
    maxCount: 30
});
```

Would work as expected with this markup:

```
<div class="my-container">
First Name: (limit <span class="my-counter"></span> characters): 
<input name="first_name" class="my-field">
</div>
<div class="my-container">
Last Name: (limit <span class="my-counter"></span> characters): 
<input name="last_name" class="my-field">
</div>
<div class="my-container">
Email: (limit <span class="my-counter"></span> characters): 
<input name="email" class="my-field">
</div>
```

[Diff with whitespace differences ignored](https://github.com/aaronrussell/jquery-simply-countable/pull/9/files?w=1).
