### PR TITLE
Permit navigation keys in countable fields

### DIFF
--- a/jquery.simplyCountable.js
+++ b/jquery.simplyCountable.js
@@ -104,7 +104,11 @@
     };
     
     countCheck();
-    countable.keyup(countCheck);
+    var navKeys = [33,34,35,36,37,38,39,40];
+    countable.keyup(function(evt) {
+      if (navKeys.indexOf(evt.which) < 0)
+        countCheck();
+    });
     countable.bind('paste', function(){
       // Wait a few miliseconds for the pasting
       setTimeout(countCheck, 5);

--- a/jquery.simplyCountable.js
+++ b/jquery.simplyCountable.js
@@ -106,7 +106,7 @@
     countCheck();
     var navKeys = [33,34,35,36,37,38,39,40];
     countable.keyup(function(evt) {
-      if (navKeys.indexOf(evt.which) < 0)
+      if ($.inArray(evt.which, navKeys) < 0)
         countCheck();
     });
     countable.bind('paste', function(){


### PR DESCRIPTION
When the countable field is maxed out and strictMax is set, navigation keys such as arrow keys and home/end are captured and effectively prevented. This patch adds a check for standard navigation keys and bypasses the countCheck.
