### PR TITLE
Ability to define options on a per element basis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Advanced usage:
         safeClass:          'safe',
         overClass:          'over',
         thousandSeparator:  ',',
+        optionsForElement:  function(element){ return {} },
         onOverCount:        function(count, countable, counter){},
         onSafeCount:        function(count, countable, counter){},
         onMaxCount:         function(count, countable, counter){}
@@ -38,6 +39,7 @@ Advanced usage:
 * `safeClass` - The CSS class applied to the counter element when it is within the maxCount figure. Defaults to `safe`.
 * `overClass` - The CSS class applied to the counter element when it exceeds the maxCount figure. Defaults to `over`.
 * `thousandSeparator` - The separator for multiples of 1,000. Set to `false` to disable. Defaults to `,`.
+* `optionsForElement` - Function called before each selected element is processed. Should return option overrides to be used during processing of that element.
 * `onOverCount` - Callback function called when counter goes over `maxCount` figure.
 * `onSafeCount` - Callback function called when counter goes below `maxCount` figure.
 * `onMaxCount` - Callback function called when in `strictMax` mode and counter hits `maxCount` figure.

--- a/demo.html
+++ b/demo.html
@@ -5,8 +5,8 @@
 	<title>jquery.simplyCountable.js demo</title>
 	<style type="text/css" media="screen">
 	  * {font-family:Helvetica, Arial, sans-serif;}
-	  body {width:800px;}
-	  pre {float:right; width:300px; background:#efefef; padding:6px 12px; margin:0; font:13px 'Courier New', Courier, monospace; font-weight:bold; color:#3b3b3b;}
+	  body {width:1000px;}
+	  pre {float:right; width:500px; background:#efefef; padding:6px 12px; margin:0; font:13px 'Courier New', Courier, monospace; font-weight:bold; color:#3b3b3b;}
 	  form {margin-bottom:30px;}
 		.safe , .over {padding:3px; color:white; font-weight:bold;}
 		.safe {background:green;}
@@ -25,13 +25,18 @@
         maxCount: 10,
         countDirection: 'up'
 		  });
+		  $('.demo4 textarea').simplyCountable({
+        optionsForElement: function(element){
+          return {counter: '#' + $(element).attr('id') + '_counter'};
+        }
+		  });
 		});
 	</script>
 </head>
 <body>
 	<h1>jQuery Simply Countable plugin demo</h1>
 	<form>
-	  <fieldset><legend>Demo 1</legend>
+	  <fieldset><legend>Demo character countdown</legend>
   		<p>You have <span id="counter"></span> characters left.</p>
   		<pre>$('#demo1').simplyCountable();</pre>
   		<p><textarea id="demo1" cols="50" rows="4"></textarea></p>
@@ -39,7 +44,7 @@
   	</fieldset>
 	</form>
 	<form>
-	  <fieldset><legend>Demo 2</legend>
+	  <fieldset><legend>Demo counting words</legend>
   		<p>You have used <span id="counter2"></span> words.</p>
       <pre>$('#demo2').simplyCountable({
   counter: '#counter2',
@@ -48,6 +53,20 @@
   countDirection: 'up'
 });</pre>
   		<p><textarea id="demo2" cols="50" rows="4"></textarea></p>
+  		<p><input type="submit" value="Submit"></p>
+  	</fieldset>
+	</form>
+	<form class="demo4">
+	  <fieldset><legend>Demo fields with independent countdowns</legend>
+  		<p>You have <span id="demo4a_counter"></span> characters left.</p>
+  		<pre>$('.demo4 textarea').simplyCountable({
+  optionsForElement: function(element){
+    return {counter: '#' + $(element).attr('id') + '_counter'};
+  }
+});</pre>
+  		<p><textarea id="demo4a" cols="50" rows="4"></textarea></p>
+  		<p>You have <span id="demo4b_counter"></span> characters left.</p>
+  		<p><textarea id="demo4b" cols="50" rows="4"></textarea></p>
   		<p><input type="submit" value="Submit"></p>
   	</fieldset>
 	</form>

--- a/jquery.simplyCountable.js
+++ b/jquery.simplyCountable.js
@@ -15,7 +15,7 @@
 
   $.fn.simplyCountable = function(options){
     
-    options = $.extend({
+    globalOptions = $.extend({
       counter:            '#counter',
       countType:          'characters',
       maxCount:           140,
@@ -24,6 +24,7 @@
       safeClass:          'safe',
       overClass:          'over',
       thousandSeparator:  ',',
+      optionsForElement:  function(element){ return {} },
       onOverCount:        function(){},
       onSafeCount:        function(){},
       onMaxCount:         function(){}
@@ -33,6 +34,7 @@
 
     return $(this).each(function(){
 
+      var options = $.extend({}, globalOptions, globalOptions.optionsForElement(this));
       var countable = $(this);
       var counter = $(options.counter);
       if (!counter.length) { return false; }


### PR DESCRIPTION
The option optionsForElement should specify a function that is passed
the current element and returns option overrides to be used while
counting the value of the current element.  This is useful when the
jQuery selector matches multiple input or textarea elements and the
counter element or counting behavior must be specific to each selected
element.
