### PR TITLE
You can specify additional event types which trigger a count.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Advanced usage:
         safeClass:          'safe',
         overClass:          'over',
         thousandSeparator:  ',',
+        additionalEvents:   '',
         onOverCount:        function(count, countable, counter){},
         onSafeCount:        function(count, countable, counter){},
         onMaxCount:         function(count, countable, counter){}
@@ -38,6 +39,7 @@ Advanced usage:
 * `safeClass` - The CSS class applied to the counter element when it is within the maxCount figure. Defaults to `safe`.
 * `overClass` - The CSS class applied to the counter element when it exceeds the maxCount figure. Defaults to `over`.
 * `thousandSeparator` - The separator for multiples of 1,000. Set to `false` to disable. Defaults to `,`.
+* `additionalEvents` - A string specifying additional event types to trigger counting.
 * `onOverCount` - Callback function called when counter goes over `maxCount` figure.
 * `onSafeCount` - Callback function called when counter goes below `maxCount` figure.
 * `onMaxCount` - Callback function called when in `strictMax` mode and counter hits `maxCount` figure.

--- a/demo.html
+++ b/demo.html
@@ -5,15 +5,17 @@
 	<title>jquery.simplyCountable.js demo</title>
 	<style type="text/css" media="screen">
 	  * {font-family:Helvetica, Arial, sans-serif;}
-	  body {width:800px;}
-	  pre {float:right; width:300px; background:#efefef; padding:6px 12px; margin:0; font:13px 'Courier New', Courier, monospace; font-weight:bold; color:#3b3b3b;}
+	  body {width:1000px;}
+	  pre {float:right; width:500px; background:#efefef; padding:6px 12px; margin:0; font:13px 'Courier New', Courier, monospace; font-weight:bold; color:#3b3b3b;}
 	  form {margin-bottom:30px;}
 		.safe , .over {padding:3px; color:white; font-weight:bold;}
 		.safe {background:green;}
 		.over {background:red;}
 	</style>
+	<link rel="stylesheet" href="http://code.jquery.com/ui/1.10.1/themes/smoothness/jquery-ui.css" />
 	<script type="text/javascript" charset="utf-8" src="http://code.jquery.com/jquery-1.10.1.min.js"></script>
   <script type="text/javascript" src="http://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+  <script type="text/javascript" src="http://code.jquery.com/ui/1.10.1/jquery-ui.js"></script>
 	<script type="text/javascript" charset="utf-8" src="jquery.simplyCountable.js"></script>
 	<script type="text/javascript" charset="utf-8">
 		$(document).ready(function()
@@ -25,6 +27,14 @@
         maxCount: 10,
         countDirection: 'up'
 		  });
+		  $('#demo5').autocomplete({
+        source: ['apple', 'blueberry', 'cherry', 'guava', 'kiwi', 'lemon', 'lime', 'mango',
+                 'nectarine', 'orange', 'peach', 'pear', 'strawberry', 'tangerine']
+      });
+		  $('#demo5').simplyCountable({
+        counter: '#counter5',
+        additionalEvents: 'autocompleteclose'
+      });
 		});
 	</script>
 </head>
@@ -48,6 +58,22 @@
   countDirection: 'up'
 });</pre>
   		<p><textarea id="demo2" cols="50" rows="4"></textarea></p>
+  		<p><input type="submit" value="Submit"></p>
+  	</fieldset>
+	</form>
+	<form>
+	  <fieldset><legend>Demo additional trigger for counting</legend>
+  		<p>Type a fruit name. You have <span id="counter5"></span> characters left.</p>
+      <pre>$('#demo5').autocomplete({
+  source: ['apple', 'blueberry', 'cherry', 'guava', 'kiwi',
+           'lemon', 'lime', 'mango', 'nectarine', 'orange',
+           'peach', 'pear', 'strawberry', 'tangerine']
+});
+$('#demo5').simplyCountable({
+  counter: '#counter5',
+  additionalEvents: 'autocompleteclose'
+});</pre>
+  		<p><input type="text" id="demo5" size="50"></p>
   		<p><input type="submit" value="Submit"></p>
   	</fieldset>
 	</form>

--- a/jquery.simplyCountable.js
+++ b/jquery.simplyCountable.js
@@ -24,6 +24,7 @@
       safeClass:          'safe',
       overClass:          'over',
       thousandSeparator:  ',',
+      additionalEvents:   '',
       onOverCount:        function(){},
       onSafeCount:        function(){},
       onMaxCount:         function(){}
@@ -114,7 +115,7 @@
       
       countCheck();
 
-      countable.on('keyup blur paste', function(e) {
+      countable.on($.trim('keyup blur paste ' + options.additionalEvents), function(e) {
         switch(e.type) {
           case 'keyup':
             // Skip navigational key presses


### PR DESCRIPTION
The additionalEvents option is a string that specifies additional event
types which should trigger a count.

For example, this can be used in conjunction with the autocomplete
plug-in to ensure that the count is updated when an item is chosen from
the menu.
