### PR TITLE
Fixed bug with incorrect counting of linebreaks in textarea

### DIFF
--- a/jquery.simplyCountable.js
+++ b/jquery.simplyCountable.js
@@ -41,6 +41,8 @@
              
         var count;
         var revCount;
+        var content = countable.val();
+        var lineBreaksCount = (content.match(/\n/g)||[]).length;
         
         var reverseCount = function(ct){
           return ct - (ct*2) + options.maxCount;
@@ -76,15 +78,13 @@
           if (countable.val() === ''){ count += 1; }
         }
         else {
-            var content = countable.val();
-            var lineBreaksCount = (content.match(/\n/g)||[]).length;
             count = options.maxCount - content.length - lineBreaksCount;
         }
         revCount = reverseCount(count);
         
         /* If strictMax set restrict further characters */
-        if (options.strictMax && count <= 0){
-          var content = countable.val();
+        if (options.strictMax && count <= 0) {
+          content = countable.val();
           if (count < 0) {
             options.onMaxCount(countInt(), countable, counter);
           }
@@ -94,7 +94,9 @@
               changeCountableValue(allowedText[0]);
             }
           }
-          else { changeCountableValue(content.substring(0, options.maxCount)); }
+          else {
+              changeCountableValue(content.substring(0, options.maxCount - lineBreaksCount));
+          }
           count = 0, revCount = options.maxCount;
         }
         

--- a/jquery.simplyCountable.js
+++ b/jquery.simplyCountable.js
@@ -75,7 +75,11 @@
           count = options.maxCount - $.trim(countable.val()).split(/\s+/).length;
           if (countable.val() === ''){ count += 1; }
         }
-        else { count = options.maxCount - countable.val().length; }
+        else {
+            var content = countable.val();
+            var lineBreaksCount = (content.match(/\n/g)||[]).length;
+            count = options.maxCount - content.length - lineBreaksCount;
+        }
         revCount = reverseCount(count);
         
         /* If strictMax set restrict further characters */


### PR DESCRIPTION
There is bug in FF, Chrome when linebreak is treated as 1 symbol when it's actually 2 symbols.

Because of this bug with such configuration:

```
<textarea maxlength="4">ff
f
</textarea>
```

browser does not allow us to enter more letters, but at the same time `simplyCounter` shows "you can enter _1_ letter".

So this PR fixes this problem.

@aaronrussell please review, this is a major bug

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aaronrussell/jquery-simply-countable/24)
<!-- Reviewable:end -->
