### PR TITLE
counter can now be a jquery object

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Simple usage:
 Advanced usage:
 
     $('#my_textarea').simplyCountable({
-        counter:            '#counter',
+        counter:            '#counter', //or $('#counter')
         countType:          'characters',
         maxCount:           140,
         strictMax:          false,
@@ -30,7 +30,7 @@ Advanced usage:
 
 ## Options
 
-* `counter` - A jQuery selector to match the 'counter' element. Defaults to `#counter`.
+* `counter` - A jQuery selector or jQuery object to match the 'counter' element. Defaults to `#counter`.
 * `countType` - Select whether to count `characters` or `words`. Defaults to `characters`.
 * `maxCount` - The maximum character (or word) count of the text input or textarea. Defaults to `140`.
 * `strictMax` - Prevents the user from being able to exceed the `maxCount`. Defaults to `false`.

--- a/jquery.simplyCountable.js
+++ b/jquery.simplyCountable.js
@@ -34,7 +34,18 @@
     return $(this).each(function(){
 
       var countable = $(this);
-      var counter = $(options.counter);
+      var counter;
+      
+      if (typeof(options.counter) == 'string'){
+        counter = $(options.counter);
+      }
+      else if (options.counter instanceof jQuery){
+        counter = options.counter;
+      }
+      else { 
+        throw new Error("The counter option must be a jQuery selector or a jQuery object.");
+      }
+
       if (!counter.length) { return false; }
       
       var countCheck = function(){


### PR DESCRIPTION
# What is this?

This PR enables the user to pass a jQuery object as a `counter:` in the options parameter.
# Why would you want to do that?

If you're dynamically creating multiple textareas on the page, then you can have all your counter elements have the same selector. You just pass in each specific element when you're initiating each textarea manually. For example:

```
$(document).ready(function(){
  $('textarea').each(function(){
   var counter = $(this).closest('.textarea-container').find('.counter');
    $(this).simplyCountable({counter: counter});
  });
});
```
