### PR TITLE
Sanity-check that options.maxCount is an int before "adding" it.

### DIFF
--- a/jquery.simplyCountable.js
+++ b/jquery.simplyCountable.js
@@ -43,7 +43,7 @@
         var revCount;
         
         var reverseCount = function(ct){
-          return ct - (ct*2) + options.maxCount;
+          return ct - (ct*2) + parseInt(options.maxCount);
         }
         
         var countInt = function(){


### PR DESCRIPTION
Try this:

```
$(element).simplyCountable({'maxCount': '123', 'countDirection': 'up'});
```

The character count will look like "-123,123" due to the arithmetic in the reverseCount function and JavaScript's usage of the + operator to append strings:

```
    var reverseCount = function(ct){
      return ct - (ct*2) + options.maxCount;
    }
```

That's slightly amusing breakage. Whenever JS sees a string on one side of a + operator, it seems to convert the other side to a string and then append them.

Why am I passing a string in the `maxCount` param? Because I have a `data-softlimit` parameter on the input fields which I'm using to get the character limit, which in this case is more of a "suggested" limit than a hard one, from the back end to the front end. So my code looks something like:

```
    var limit = $e.attr('data-softlimit'),
      $counter = $('<div class="softlimit-counter">')
        .attr('id', counterId)
        .html(Drupal.t('<span class="count"></span>/@limit characters (recommendation)', {'@limit': limit}));
    $e.after($counter);
    $e.simplyCountable({'counter': '#' + counterId + ' .count', 'maxCount': limit, 'countDirection': 'up'})
```

…But a similar issue could probably happen if I were doing something more common like getting the limit from `$e.attr('maxlength')`.

I could make the int on my side, but why not idiot-proof it in the library itself? It's just a one-line fix; I don't think we need to `parseInt(options.maxCount)` elsewhere because in most other places, we're subtracting with this value, not adding it - or casting it to a string anyway.
