### PR TITLE
Support contenteditable divs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 jQuery plugin that provides a character counter for any text input or textarea. Works when typing and pasting text using the mouse.
 
-* version - 0.5.0
+* version - 0.5.1
 * homepage - [http://github.com/aaronrussell/jquery-simply-countable/](http://github.com/aaronrussell/jquery-simply-countable/)
 * author - [Aaron Russell](http://www.aaronrussell.co.uk)
 

--- a/jquery.simplyCountable.js
+++ b/jquery.simplyCountable.js
@@ -69,18 +69,29 @@
         var changeCountableValue = function(val){
           countable.val(val).trigger('change');
         }
+
+        var getCountableContent = function() {
+          var textContent;
+
+          if( countable.prop("tagName") == 'DIV' && countable.attr('contenteditable') == 'true' ) {
+            textContent = countable.text();
+          } else {
+            textContent = countable.val();
+          }
+          return textContent;
+        }
         
         /* Calculates count for either words or characters */
         if (options.countType === 'words'){
-          count = options.maxCount - $.trim(countable.val()).split(/\s+/).length;
-          if (countable.val() === ''){ count += 1; }
+          count = options.maxCount - $.trim(getCountableContent()).split(/\s+/).length;
+          if (getCountableContent() === ''){ count += 1; }
         }
-        else { count = options.maxCount - countable.val().length; }
+        else { count = options.maxCount - getCountableContent().length; }
         revCount = reverseCount(count);
         
         /* If strictMax set restrict further characters */
         if (options.strictMax && count <= 0){
-          var content = countable.val();
+          var content = getCountableContent();
           if (count < 0) {
             options.onMaxCount(countInt(), countable, counter);
           }

--- a/jquery.simplyCountable.js
+++ b/jquery.simplyCountable.js
@@ -2,7 +2,7 @@
 * jQuery Simply Countable plugin
 * Provides a character counter for any text input or textarea
 * 
-* @version  0.4.2
+* @version  0.5.1
 * @homepage http://github.com/aaronrussell/jquery-simply-countable/
 * @author   Aaron Russell (http://www.aaronrussell.co.uk)
 *

--- a/simplyCountable.jquery.json
+++ b/simplyCountable.jquery.json
@@ -1,6 +1,6 @@
 {
   "name": "simplyCountable",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "title": "jQuery Simply Countable",
   "description": "jQuery plugin that provides a character counter for any text input or textarea.",
   "author": {


### PR DESCRIPTION
There was only support for inputs or textareas because of the usage of `.val()` in order to get the text content.

But I found that I needed it a few times in the context of a WYSIWYG editor, which is inevitably a div with `contenteditable` set to true.

So what I've done is simply extracted the calls to `countable.val()` into a function that splits up elements that support `.val()` and elements that support `.text()`.
